### PR TITLE
Use React as peer dependency, update Readme syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ Define your routes with a single file:
 const React = require('react'); 
 const routesDub = require('react-routes-dub');
 
-module.exports = routesDub({
-  React
-}, [
+export const {
+  DubProvider,
+  Link,
+  Route,
+  pathFor
+} = routesDub([
   {
     name: 'home',
     pattern: '/'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-routes-dub",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Chadwick Dahlquist",
   "description": "Stupid-easy React routing for the browser in 200 lines of code and with a single dependency.",
   "license": "MIT",
@@ -15,6 +15,9 @@
   },
   "dependencies": {
     "path-to-regexp": "^2.4.0"
+  },
+  "peerDependencies": {
+    "react": "^16.4.2"
   },
   "keywords": [
     "history-api",

--- a/src/react-routes-dub.js
+++ b/src/react-routes-dub.js
@@ -1,8 +1,19 @@
+const React = require('react');
 const pathToRegexp = require('path-to-regexp');
 const BoundHistory = require('./bound-history');
 
-module.exports = function routesDub (options = {}, routes = []) {
-  const { React } = options;
+module.exports = function routesDub (routes = [], routesLegacySupport=[]) {
+  if (routes.React){ // support the legacy api
+    try { // make sure a console doesn't break IE
+      console.warn(
+        "DEPRECTED usage of #routesDub, arguments have change\n" +
+        'react-routes-dub has made React a peer dependency ' +
+        'and deprecated support for the `routesDub(options, routes)` api.' +
+        'Please use `routesDub(routes)` instead.'
+      );
+    } catch (e) {}
+    routes = routesLegacySupport;
+  }
 
   const routesCompiled = compileRoutes(routes);
   const routesCompiledByName = routesCompiled.reduce((accu, route) => {
@@ -20,7 +31,7 @@ module.exports = function routesDub (options = {}, routes = []) {
     });
   }
 
-  const { Provider, Consumer } = options.React.createContext();
+  const { Provider, Consumer } = React.createContext();
 
   function getContext () {
     const currentRoute = getCurrentRoute();

--- a/test/src/routes.js
+++ b/test/src/routes.js
@@ -1,9 +1,7 @@
 const React = require('react'); 
 const routesDub = require('./react-routes-dub');
 
-module.exports = routesDub({
-  React
-}, [
+module.exports = routesDub([
   {
     name: 'alpha',
     pattern: '/alpha'


### PR DESCRIPTION
Using peer dependencies seems to be the convention for utilizing the same
instance of an imported third party library.

Deprecated original API since React no longer needs to be passed as an
argument.  Also passing options as the first arg seems odd.

Updated README to reflect this change along with using more es6-esk
syntax for doing the export (since this is a react module).